### PR TITLE
Fix environment name and script extension in configuration files

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,7 +1,9 @@
+require("dotenv").config();
+
 module.exports = {
   apps: [
     {
-      name: "cat-production",
+      name: process.env.ECOSYTEM_NAME,
       script: "./src/auth/connection.js",
       exec_mode: "fork",
       instances: 1,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src",
   "scripts": {
     "start": "npx node ./src/auth/connection.js",
-    "start:pm2": "pm2 start ecosystem.config",
+    "start:pm2": "pm2 start ecosystem.config.js",
     "restart": "npx pm2 restart all",
     "stop": "npx pm2 stop all",
     "logs": "npx pm2 monit"


### PR DESCRIPTION
Correct the environment name in `ecosystem.config.js` and update the script extension in the `start:pm2` command of `package.json`.