### PR TITLE
Add comment to command prefix validator

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -10,7 +10,7 @@ const commandPrefix = makeValidator((input) => {
   }
   return input;
 });
-
+//a
 try {
   env = cleanEnv(process.env, {
     BOT_GLOBAL_PREFIX: commandPrefix(),


### PR DESCRIPTION
Include a comment in the command prefix validator for better code clarity.